### PR TITLE
Fix Program 404 on unauthenticated access

### DIFF
--- a/grants/views/program.py
+++ b/grants/views/program.py
@@ -37,10 +37,10 @@ class ProgramMixin:
     def dispatch(self, *args, **kwargs):
         self.program_slug = kwargs.pop("program")
         self.program = Program.objects.get(slug=self.program_slug)
-        if self.login_required and not self.request.user:
-            return redirect("login")
+        if self.login_required and not self.request.user.is_authenticated:
+            return redirect("account_login")
         if self.login_required and not self.program.user_allowed(self.request.user):
-            raise Http404("Not logged in")
+            raise Http404("You don't have access to this program")
         return super().dispatch(*args, **kwargs)
 
     def render_to_response(self, context, **kwargs):


### PR DESCRIPTION
## Summary
- Fixed authentication check in ProgramMixin that was using `not self.request.user` instead of `is_authenticated`
- Now properly redirects unauthenticated users to login page instead of showing 404
- Improved error message for authenticated users without access

## Test plan
- [x] Tests pass
- [ ] Access a program page while not logged in - should redirect to login
- [ ] Access a program page while logged in without access - should show "You don't have access" message

Fixes #4