### PR TITLE
Consolidate applicant visibility check and close gaps

### DIFF
--- a/grants/models.py
+++ b/grants/models.py
@@ -63,6 +63,14 @@ class Program(models.Model):
             self.created_by_id and self.created_by_id == user.pk
         )
 
+    def applicants_visible_to(self, user):
+        """
+        Applicants the given user is allowed to see in the review flow.
+        Excludes the user's own application (identified by email — the only
+        reliable link since Applicant has no FK to User).
+        """
+        return self.applicants.exclude(email=user.email)
+
 
 class Resource(models.Model):
     """

--- a/grants/tests/test_models.py
+++ b/grants/tests/test_models.py
@@ -23,6 +23,26 @@ class TestProgramModel:
     def test_urls_apply(self, program):
         assert program.urls.apply == "/test-program/apply/"
 
+    def test_applicants_visible_to_excludes_user_by_email(self, program, user):
+        own = baker.make("grants.Applicant", program=program, email=user.email, name="Self")
+        other = baker.make("grants.Applicant", program=program, email="other@example.com", name="Other")
+        visible = list(program.applicants_visible_to(user))
+        assert own not in visible
+        assert other in visible
+
+    def test_applicants_visible_to_does_not_exclude_by_name(self, program, user):
+        """Name collisions must NOT cause other applicants to be hidden."""
+        user.first_name = "Ada"
+        user.last_name = "Lovelace"
+        user.save()
+        same_name = baker.make(
+            "grants.Applicant",
+            program=program,
+            email="different@example.com",
+            name="Ada Lovelace",
+        )
+        assert same_name in list(program.applicants_visible_to(user))
+
 
 class TestQuestionModel:
     def test_str_returns_question_text(self, question):

--- a/grants/tests/test_views.py
+++ b/grants/tests/test_views.py
@@ -96,6 +96,50 @@ class TestApplicantViewAndScoring:
         assert "3.0" in score.score_history
 
 
+class TestOwnApplicationHiddenFromReviewer:
+    """A user who also applied must never see their own application."""
+
+    def test_list_excludes_own_application(self, client_logged_in, program, user):
+        own = baker.make("grants.Applicant", program=program, email=user.email, name="Self")
+        other = baker.make("grants.Applicant", program=program, email="o@example.com", name="Other")
+        response = client_logged_in.get(f"/{program.slug}/applicants/")
+        body = response.content.decode()
+        assert other.name in body
+        assert own.name not in body
+
+    def test_detail_returns_404_for_own_application(self, client_logged_in, program, user):
+        own = baker.make("grants.Applicant", program=program, email=user.email, name="Self")
+        response = client_logged_in.get(f"/{program.slug}/applicants/{own.id}/")
+        assert response.status_code == 404
+
+    def test_allocations_returns_404_for_own_application(self, client_logged_in, program, user):
+        own = baker.make("grants.Applicant", program=program, email=user.email, name="Self")
+        response = client_logged_in.get(
+            f"/{program.slug}/applicants/{own.id}/allocations/"
+        )
+        assert response.status_code == 404
+
+    def test_random_unscored_skips_own_application(self, client_logged_in, program, user):
+        baker.make("grants.Applicant", program=program, email=user.email, name="Self")
+        response = client_logged_in.get(f"/{program.slug}/applicants/random-unscored/")
+        assert response.status_code == 302
+        assert response.url.rstrip("/").endswith("/applicants")
+
+    def test_same_name_applicant_still_visible(self, client_logged_in, program, user):
+        """Regression: applicants with the same name as the reviewer must not be hidden."""
+        user.first_name = "Ada"
+        user.last_name = "Lovelace"
+        user.save()
+        namesake = baker.make(
+            "grants.Applicant",
+            program=program,
+            email="different@example.com",
+            name="Ada Lovelace",
+        )
+        response = client_logged_in.get(f"/{program.slug}/applicants/")
+        assert namesake.name in response.content.decode()
+
+
 class TestProgramQuestionsView:
     def test_requires_authentication(self, client, program):
         response = client.get(f"/{program.slug}/questions/")

--- a/grants/views/program.py
+++ b/grants/views/program.py
@@ -7,7 +7,7 @@ from django import forms
 from django.db.models import Q
 from django.http import Http404
 from django.http import HttpResponse
-from django.shortcuts import redirect, render
+from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.views.generic import FormView, ListView, TemplateView, UpdateView, View
 
@@ -91,19 +91,27 @@ class ProgramHome(ProgramMixin, TemplateView):
     template_name = "program-home.html"
 
     def get_context_data(self):
-        active_applicants = self.program.applicants.exclude(status="rejected")
+        active_applicants = self.program.applicants_visible_to(
+            self.request.user
+        ).exclude(status="rejected")
         users = list(self.program.users.all())
         for user in users:
-            user.num_votes = user.scores.filter(
-                applicant__program=self.program,
-                applicant__status__in=["pending", "accepted"],
-            ).count()
+            user.num_votes = (
+                user.scores.filter(
+                    applicant__program=self.program,
+                    applicant__status__in=["pending", "accepted"],
+                )
+                .exclude(applicant__email=user.email)
+                .count()
+            )
         return {
             "num_applicants": active_applicants.count(),
             "num_scored": self.request.user.scores.filter(
                 applicant__program=self.program,
                 applicant__status__in=["pending", "accepted"],
-            ).count(),
+            )
+            .exclude(applicant__email=self.request.user.email)
+            .count(),
             "users": users,
         }
 
@@ -247,9 +255,7 @@ class ProgramApplicants(ProgramMixin, ListView):
         self.viewing_rejected = (
             can_manage and self.request.GET.get("status") == "rejected"
         )
-        qs = self.program.applicants.exclude(
-            Q(email=self.request.user.email) | Q(name=self.request.user.get_full_name())
-        )
+        qs = self.program.applicants_visible_to(self.request.user)
         if self.viewing_rejected:
             qs = qs.filter(status="rejected")
         else:
@@ -321,15 +327,10 @@ class ProgramApplicantsCsv(ProgramMixin, ListView):
             self.sort = "score"
         else:
             self.sort = "applied"
-        # Fetch applicants
-        # but don't let a user see their own request
-        # and exclude rejected applicants
+        # Fetch applicants visible to this user, excluding rejected
         applicants = list(
-            self.program.applicants.exclude(
-                Q(email=self.request.user.email)
-                | Q(name=self.request.user.get_full_name())
-                | Q(status="rejected")
-            )
+            self.program.applicants_visible_to(self.request.user)
+            .exclude(status="rejected")
             .prefetch_related("scores")
             .order_by("-applied")
         )
@@ -400,9 +401,9 @@ class ProgramApplicantView(ProgramMixin, TemplateView):
     template_name = "applicant-view.html"
 
     def get(self, request, applicant_id):
-        applicant = self.program.applicants.exclude(
-            Q(email=self.request.user.email) | Q(name=self.request.user.get_full_name())
-        ).get(pk=applicant_id)
+        applicant = get_object_or_404(
+            self.program.applicants_visible_to(self.request.user), pk=applicant_id
+        )
         questions = list(self.program.questions.order_by("order"))
         for question in questions:
             question.answer = question.answers.filter(applicant=applicant).first()
@@ -477,12 +478,8 @@ class RandomUnscoredApplicant(ProgramMixin, View):
 
     def get(self, request):
         applicant = (
-            self.program.applicants.exclude(
-                Q(scores__user=self.request.user)
-                | Q(email=self.request.user.email)
-                | Q(name=self.request.user.get_full_name())
-                | Q(status="rejected")
-            )
+            self.program.applicants_visible_to(self.request.user)
+            .exclude(Q(scores__user=self.request.user) | Q(status="rejected"))
             .order_by("?")
             .first()
         )
@@ -500,9 +497,13 @@ class ApplicantAllocations(ProgramMixin, FormView):
     form_class = AllocationForm
     template_name = "applicant-allocations.html"
 
-    def dispatch(self, *args, **kwargs):
-        self.applicant = Applicant.objects.get(pk=kwargs.pop("applicant_id"))
-        return super().dispatch(*args, **kwargs)
+    def dispatch(self, request, *args, **kwargs):
+        applicant_id = kwargs.pop("applicant_id")
+        self.program = get_object_or_404(Program, slug=kwargs["program"])
+        self.applicant = get_object_or_404(
+            self.program.applicants_visible_to(request.user), pk=applicant_id
+        )
+        return super().dispatch(request, *args, **kwargs)
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()


### PR DESCRIPTION
## Summary

Audit of all places where applicants are shown to reviewers, ensuring a user who also applied never sees their own application.

- New `Program.applicants_visible_to(user)` helper — excludes by **email only**, the only reliable link since `Applicant` has no FK to User
- Replaces scattered `Q(email=...) | Q(name=...)` exclusions across 4 views
- Drops the name-based check: `get_full_name()` may not match what was typed at apply time, and worse, it caused false positives where same-named applicants got hidden from reviewers

## Fixes

- `ApplicantAllocations` no longer uses raw `Applicant.objects.get(pk=...)` — now scopes to the program and excludes the reviewer's own application
- `ProgramHome` totals (`num_applicants`, `num_scored`, `num_votes`) exclude own application
- `ProgramApplicantView` and `ApplicantAllocations` return 404 (not 500) when blocked

## Tests

7 new tests covering:
- Model helper: email-based exclusion
- Model helper: same-name applicants are NOT hidden (regression)
- List view hides own application
- Detail view returns 404 for own application
- Allocations view returns 404 for own application
- Random-unscored skips own application
- Same-name applicant still visible in list