### PR TITLE
Make question filtering opt-in and support integer ranges

### DIFF
--- a/grants/forms.py
+++ b/grants/forms.py
@@ -8,16 +8,12 @@ from .models import Allocation, Program, Question, Resource, Score
 
 class QuestionForm(forms.ModelForm):
     class Meta:
-        fields = ["question", "type", "required"]
+        fields = ["question", "type", "required", "filterable"]
         model = Question
 
     def clean_type(self):
         type = self.cleaned_data["type"]
-        if (
-            self.instance
-            and type != self.instance.type
-            and self.instance.answers.exists()
-        ):
+        if self.instance and type != self.instance.type and self.instance.answers.exists():
             raise forms.ValidationError("Cannot change once this question has answers")
         return type
 
@@ -33,9 +29,7 @@ class BaseApplyForm(forms.Form):
     def clean_email(self):
         email = self.cleaned_data["email"]
         if self.program.applicants.filter(email=email).exists():
-            raise forms.ValidationError(
-                "An application with that email address has already been submitted."
-            )
+            raise forms.ValidationError("An application with that email address has already been submitted.")
         return email
 
 
@@ -93,9 +87,7 @@ class AllocationForm(forms.ModelForm):
     def clean_resource(self):
         resource = self.cleaned_data["resource"]
         if self.applicant.allocations.filter(resource=resource).exists():
-            raise forms.ValidationError(
-                "That resource is already allocated. Delete it if you wish to change it."
-            )
+            raise forms.ValidationError("That resource is already allocated. Delete it if you wish to change it.")
         return resource
 
 
@@ -125,9 +117,7 @@ class ProgramForm(forms.ModelForm):
 class RejectApplicantForm(forms.Form):
     rejection_reason = forms.CharField(
         required=False,
-        widget=forms.Textarea(
-            attrs={"rows": 3, "placeholder": "Optional reason for rejection"}
-        ),
+        widget=forms.Textarea(attrs={"rows": 3, "placeholder": "Optional reason for rejection"}),
         label="Reason",
     )
 

--- a/grants/migrations/0017_question_filterable.py
+++ b/grants/migrations/0017_question_filterable.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("grants", "0016_applicant_rejection_reason_applicant_status_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="question",
+            name="filterable",
+            field=models.BooleanField(
+                default=False,
+                help_text="Show this question as a filter on the applicants list",
+            ),
+        ),
+    ]

--- a/grants/migrations/0018_set_boolean_questions_filterable.py
+++ b/grants/migrations/0018_set_boolean_questions_filterable.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from django.db import migrations
+
+
+def set_boolean_questions_filterable(apps, schema_editor):
+    Question = apps.get_model("grants", "Question")
+    Question.objects.filter(type="boolean").update(filterable=True)
+
+
+def unset_filterable(apps, schema_editor):
+    Question = apps.get_model("grants", "Question")
+    Question.objects.update(filterable=False)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("grants", "0017_question_filterable"),
+    ]
+
+    operations = [
+        migrations.RunPython(set_boolean_questions_filterable, unset_filterable),
+    ]

--- a/grants/models.py
+++ b/grants/models.py
@@ -59,9 +59,7 @@ class Program(models.Model):
 
     def user_can_manage(self, user):
         """Returns True if user is a superuser or the program creator."""
-        return user.is_superuser or (
-            self.created_by_id and self.created_by_id == user.pk
-        )
+        return user.is_superuser or (self.created_by_id and self.created_by_id == user.pk)
 
     def applicants_visible_to(self, user):
         """
@@ -85,9 +83,7 @@ class Resource(models.Model):
         ("accomodation", "Accomodation"),
     ]
 
-    program = models.ForeignKey(
-        Program, related_name="resources", on_delete=models.CASCADE
-    )
+    program = models.ForeignKey(Program, related_name="resources", on_delete=models.CASCADE)
     name = models.CharField(max_length=100)
     type = models.CharField(max_length=50, choices=TYPE_CHOICES)
     amount = models.PositiveIntegerField()
@@ -125,12 +121,14 @@ class Question(models.Model):
         ("integer", "Integer value"),
     ]
 
-    program = models.ForeignKey(
-        Program, related_name="questions", on_delete=models.CASCADE
-    )
+    program = models.ForeignKey(Program, related_name="questions", on_delete=models.CASCADE)
     type = models.CharField(max_length=50, choices=TYPE_CHOICES)
     question = models.TextField()
     required = models.BooleanField(default=False)
+    filterable = models.BooleanField(
+        default=False,
+        help_text="Show this question as a filter on the applicants list",
+    )
     order = models.IntegerField(default=0)
 
     class urls(Urls):
@@ -141,6 +139,47 @@ class Question(models.Model):
 
     def can_delete(self):
         return not self.answers.exists()
+
+    def can_filter(self):
+        return self.filterable and self.type in ("boolean", "integer")
+
+    def integer_answer_values(self):
+        values = []
+        for answer in self.answers.all():
+            try:
+                values.append(int(answer.answer))
+            except (TypeError, ValueError):
+                continue
+        return values
+
+    def integer_filter_ranges(self):
+        """
+        Returns inclusive (low, high) buckets for filtering integer answers,
+        derived from quartiles of the actual data. Returns [] if there is
+        no usable data.
+        """
+        if self.type != "integer":
+            return []
+        values = sorted(self.integer_answer_values())
+        if not values:
+            return []
+        mn, mx = values[0], values[-1]
+        if mn == mx:
+            return [(mn, mn)]
+        n = len(values)
+        # Quartile breakpoints (inclusive of min and max)
+        breakpoints = sorted({mn, values[n // 4], values[n // 2], values[(3 * n) // 4], mx})
+        ranges = []
+        for i, low in enumerate(breakpoints[:-1]):
+            next_bp = breakpoints[i + 1]
+            if i == len(breakpoints) - 2:
+                high = next_bp
+            else:
+                high = next_bp - 1
+            if high < low:
+                high = low
+            ranges.append((low, high))
+        return ranges
 
 
 class Applicant(models.Model):
@@ -154,9 +193,7 @@ class Applicant(models.Model):
         ("rejected", "Rejected"),
     ]
 
-    program = models.ForeignKey(
-        Program, related_name="applicants", on_delete=models.CASCADE
-    )
+    program = models.ForeignKey(Program, related_name="applicants", on_delete=models.CASCADE)
     name = models.TextField()
     email = models.EmailField()
 
@@ -201,12 +238,8 @@ class Allocation(models.Model):
     An allocation of some Resources to an Applicant.
     """
 
-    applicant = models.ForeignKey(
-        Applicant, related_name="allocations", on_delete=models.CASCADE
-    )
-    resource = models.ForeignKey(
-        Resource, related_name="allocations", on_delete=models.CASCADE
-    )
+    applicant = models.ForeignKey(Applicant, related_name="allocations", on_delete=models.CASCADE)
+    resource = models.ForeignKey(Resource, related_name="allocations", on_delete=models.CASCADE)
     amount = models.PositiveIntegerField()
 
     class Meta:
@@ -220,12 +253,8 @@ class Answer(models.Model):
     An applicant's answer to a question.
     """
 
-    applicant = models.ForeignKey(
-        Applicant, related_name="answers", on_delete=models.CASCADE
-    )
-    question = models.ForeignKey(
-        Question, related_name="answers", on_delete=models.CASCADE
-    )
+    applicant = models.ForeignKey(Applicant, related_name="answers", on_delete=models.CASCADE)
+    question = models.ForeignKey(Question, related_name="answers", on_delete=models.CASCADE)
     answer = models.TextField()
 
     class Meta:
@@ -239,12 +268,8 @@ class Score(models.Model):
     A score and optional comment on an applicant by a user.
     """
 
-    applicant = models.ForeignKey(
-        Applicant, related_name="scores", on_delete=models.CASCADE
-    )
-    user = models.ForeignKey(
-        "users.User", related_name="scores", on_delete=models.CASCADE
-    )
+    applicant = models.ForeignKey(Applicant, related_name="scores", on_delete=models.CASCADE)
+    user = models.ForeignKey("users.User", related_name="scores", on_delete=models.CASCADE)
     score = models.FloatField(
         blank=True,
         null=True,
@@ -264,8 +289,7 @@ class Score(models.Model):
         ]
         constraints = [
             models.CheckConstraint(
-                condition=models.Q(score__isnull=True)
-                | (models.Q(score__gte=1) & models.Q(score__lte=5)),
+                condition=models.Q(score__isnull=True) | (models.Q(score__gte=1) & models.Q(score__lte=5)),
                 name="score_range_1_to_5",
             ),
         ]

--- a/grants/tests/test_models.py
+++ b/grants/tests/test_models.py
@@ -61,6 +61,60 @@ class TestQuestionModel:
         assert question.can_delete() is False
 
 
+class TestQuestionFiltering:
+    def test_can_filter_true_for_filterable_boolean(self, program):
+        q = baker.make("grants.Question", program=program, type="boolean", filterable=True)
+        assert q.can_filter() is True
+
+    def test_can_filter_true_for_filterable_integer(self, program):
+        q = baker.make("grants.Question", program=program, type="integer", filterable=True)
+        assert q.can_filter() is True
+
+    def test_can_filter_false_when_flag_off(self, program):
+        q = baker.make("grants.Question", program=program, type="boolean", filterable=False)
+        assert q.can_filter() is False
+
+    def test_can_filter_false_for_text_even_if_flagged(self, program):
+        q = baker.make("grants.Question", program=program, type="text", filterable=True)
+        assert q.can_filter() is False
+
+    def test_integer_filter_ranges_empty_when_no_answers(self, program):
+        q = baker.make("grants.Question", program=program, type="integer", filterable=True)
+        assert q.integer_filter_ranges() == []
+
+    def test_integer_filter_ranges_single_value(self, program):
+        q = baker.make("grants.Question", program=program, type="integer", filterable=True)
+        applicant = baker.make("grants.Applicant", program=program, email="a@example.com")
+        baker.make("grants.Answer", applicant=applicant, question=q, answer="42")
+        assert q.integer_filter_ranges() == [(42, 42)]
+
+    def test_integer_filter_ranges_returns_disjoint_buckets(self, program):
+        q = baker.make("grants.Question", program=program, type="integer", filterable=True)
+        for i, val in enumerate([10, 50, 100, 200, 500, 1000, 2000, 5000]):
+            applicant = baker.make("grants.Applicant", program=program, email=f"a{i}@example.com")
+            baker.make("grants.Answer", applicant=applicant, question=q, answer=str(val))
+        ranges = q.integer_filter_ranges()
+        assert ranges, "should produce buckets"
+        # Buckets must be disjoint and cover min..max
+        for (_, high), (next_low, _) in zip(ranges, ranges[1:]):
+            assert high < next_low
+        assert ranges[0][0] == 10
+        assert ranges[-1][1] == 5000
+
+    def test_integer_filter_ranges_ignores_non_numeric(self, program):
+        q = baker.make("grants.Question", program=program, type="integer", filterable=True)
+        a1 = baker.make("grants.Applicant", program=program, email="a1@example.com")
+        a2 = baker.make("grants.Applicant", program=program, email="a2@example.com")
+        baker.make("grants.Answer", applicant=a1, question=q, answer="100")
+        baker.make("grants.Answer", applicant=a2, question=q, answer="not a number")
+        # Should not crash and should still produce a valid range from the one parseable value
+        assert q.integer_filter_ranges() == [(100, 100)]
+
+    def test_integer_filter_ranges_empty_for_non_integer_question(self, program):
+        q = baker.make("grants.Question", program=program, type="boolean", filterable=True)
+        assert q.integer_filter_ranges() == []
+
+
 class TestApplicantModel:
     def test_str_returns_name(self, applicant):
         assert str(applicant) == "Test Applicant"

--- a/grants/tests/test_views.py
+++ b/grants/tests/test_views.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import pytest
 from model_bakery import baker
 
 from grants.models import Applicant, Program, Score
@@ -68,6 +69,86 @@ class TestProgramApplicantsView:
         assert applicant.name in response.content.decode()
 
 
+class TestProgramApplicantsFilters:
+    """Filter UI is only shown to managers; make user the program manager."""
+
+    @pytest.fixture
+    def manager_client(self, client_logged_in, program, user):
+        program.created_by = user
+        program.save()
+        return client_logged_in
+
+    def test_filterable_boolean_question_appears_in_filter_ui(self, manager_client, program):
+        baker.make(
+            "grants.Question",
+            program=program,
+            type="boolean",
+            question="Is this your first time?",
+            filterable=True,
+        )
+        response = manager_client.get(f"/{program.slug}/applicants/")
+        body = response.content.decode()
+        assert "Filter by Question" in body
+        assert "Is this your first time?" in body
+
+    def test_non_filterable_boolean_question_hidden_from_filter_ui(self, manager_client, program):
+        baker.make(
+            "grants.Question",
+            program=program,
+            type="boolean",
+            question="Some private flag",
+            filterable=False,
+        )
+        response = manager_client.get(f"/{program.slug}/applicants/")
+        assert "Filter by Question" not in response.content.decode()
+
+    def test_boolean_yes_filter_filters_applicants(self, manager_client, program):
+        q = baker.make("grants.Question", program=program, type="boolean", filterable=True)
+        yes_applicant = baker.make("grants.Applicant", program=program, name="YesPerson", email="yes@example.com")
+        no_applicant = baker.make("grants.Applicant", program=program, name="NoPerson", email="no@example.com")
+        baker.make("grants.Answer", applicant=yes_applicant, question=q, answer="True")
+        baker.make("grants.Answer", applicant=no_applicant, question=q, answer="False")
+        response = manager_client.get(f"/{program.slug}/applicants/?q{q.id}=yes")
+        body = response.content.decode()
+        assert "YesPerson" in body
+        assert "NoPerson" not in body
+
+    def test_integer_question_shows_range_buttons(self, manager_client, program):
+        q = baker.make("grants.Question", program=program, type="integer", filterable=True, question="Years experience")
+        for i, val in enumerate([1, 5, 10, 20]):
+            a = baker.make("grants.Applicant", program=program, email=f"a{i}@example.com")
+            baker.make("grants.Answer", applicant=a, question=q, answer=str(val))
+        response = manager_client.get(f"/{program.slug}/applicants/")
+        body = response.content.decode()
+        assert "Years experience" in body
+        # At least one range button exists with low-high href format
+        assert f"q{q.id}=1-" in body or f"q{q.id}=" in body
+
+    def test_integer_range_filter_filters_applicants(self, manager_client, program):
+        q = baker.make("grants.Question", program=program, type="integer", filterable=True)
+        small = baker.make("grants.Applicant", program=program, name="SmallBudget", email="s@example.com")
+        large = baker.make("grants.Applicant", program=program, name="LargeBudget", email="l@example.com")
+        baker.make("grants.Answer", applicant=small, question=q, answer="100")
+        baker.make("grants.Answer", applicant=large, question=q, answer="5000")
+        response = manager_client.get(f"/{program.slug}/applicants/?q{q.id}=0-1000")
+        body = response.content.decode()
+        assert "SmallBudget" in body
+        assert "LargeBudget" not in body
+
+    def test_filter_does_not_apply_for_non_managers(self, client_logged_in, program):
+        """Non-managers should not be able to use filters even if URL has them."""
+        q = baker.make("grants.Question", program=program, type="boolean", filterable=True)
+        yes_applicant = baker.make("grants.Applicant", program=program, name="YesPerson", email="yes@example.com")
+        no_applicant = baker.make("grants.Applicant", program=program, name="NoPerson", email="no@example.com")
+        baker.make("grants.Answer", applicant=yes_applicant, question=q, answer="True")
+        baker.make("grants.Answer", applicant=no_applicant, question=q, answer="False")
+        response = client_logged_in.get(f"/{program.slug}/applicants/?q{q.id}=yes")
+        body = response.content.decode()
+        # Filter should be ignored — both applicants visible
+        assert "YesPerson" in body
+        assert "NoPerson" in body
+
+
 class TestApplicantViewAndScoring:
     def test_view_applicant(self, client_logged_in, program, applicant):
         response = client_logged_in.get(f"/{program.slug}/applicants/{applicant.id}/")
@@ -83,9 +164,7 @@ class TestApplicantViewAndScoring:
         assert score.score == 4.0
         assert score.comment == "Great application"
 
-    def test_update_score_tracks_history(
-        self, client_logged_in, program, applicant, user
-    ):
+    def test_update_score_tracks_history(self, client_logged_in, program, applicant, user):
         baker.make("grants.Score", applicant=applicant, user=user, score=3.0)
         client_logged_in.post(
             f"/{program.slug}/applicants/{applicant.id}/",
@@ -114,9 +193,7 @@ class TestOwnApplicationHiddenFromReviewer:
 
     def test_allocations_returns_404_for_own_application(self, client_logged_in, program, user):
         own = baker.make("grants.Applicant", program=program, email=user.email, name="Self")
-        response = client_logged_in.get(
-            f"/{program.slug}/applicants/{own.id}/allocations/"
-        )
+        response = client_logged_in.get(f"/{program.slug}/applicants/{own.id}/allocations/")
         assert response.status_code == 404
 
     def test_random_unscored_skips_own_application(self, client_logged_in, program, user):

--- a/grants/views/program.py
+++ b/grants/views/program.py
@@ -25,6 +25,17 @@ from ..forms import (
 from ..models import Answer, Applicant, Program, Question, Resource, Score
 
 
+def _parse_integer_range(value):
+    """Parses a 'low-high' string from a filter query param into (int, int)."""
+    if not value or "-" not in value:
+        return None
+    low_str, _, high_str = value.partition("-")
+    try:
+        return int(low_str), int(high_str)
+    except (TypeError, ValueError):
+        return None
+
+
 def index(request):
     return render(
         request,
@@ -256,18 +267,37 @@ class ProgramApplicants(ProgramMixin, ListView):
         else:
             qs = qs.exclude(status="rejected")
 
-        # Boolean question filters (managers only)
-        self.boolean_questions = list(self.program.questions.filter(type="boolean").order_by("order"))
+        # Question-based filters (managers only); opt-in via Question.filterable.
+        self.filter_questions = list(
+            self.program.questions.filter(filterable=True, type__in=["boolean", "integer"]).order_by("order")
+        )
         self.active_filters = {}
         if can_manage:
-            for bq in self.boolean_questions:
-                filter_val = self.request.GET.get(f"q{bq.id}")
-                if filter_val in ("yes", "no"):
-                    self.active_filters[bq.id] = filter_val
+            for fq in self.filter_questions:
+                filter_val = self.request.GET.get(f"q{fq.id}")
+                if not filter_val:
+                    continue
+                if fq.type == "boolean" and filter_val in ("yes", "no"):
+                    self.active_filters[fq.id] = filter_val
                     answer_value = "True" if filter_val == "yes" else "False"
-                    matching_applicant_ids = Answer.objects.filter(question=bq, answer=answer_value).values_list(
+                    matching_applicant_ids = Answer.objects.filter(question=fq, answer=answer_value).values_list(
                         "applicant_id", flat=True
                     )
+                    qs = qs.filter(pk__in=matching_applicant_ids)
+                elif fq.type == "integer":
+                    parsed = _parse_integer_range(filter_val)
+                    if parsed is None:
+                        continue
+                    low, high = parsed
+                    matching_applicant_ids = []
+                    for ans in Answer.objects.filter(question=fq):
+                        try:
+                            v = int(ans.answer)
+                        except (TypeError, ValueError):
+                            continue
+                        if low <= v <= high:
+                            matching_applicant_ids.append(ans.applicant_id)
+                    self.active_filters[fq.id] = filter_val
                     qs = qs.filter(pk__in=matching_applicant_ids)
 
         applicants = list(qs.prefetch_related("scores").order_by("-applied"))
@@ -288,20 +318,29 @@ class ProgramApplicants(ProgramMixin, ListView):
         context = super().get_context_data()
         context["sort"] = self.sort
         context["viewing_rejected"] = self.viewing_rejected
-        # Build filter URLs for boolean questions
+        # Build filter UI data for each filterable question
         base_params = {k: v for k, v in self.request.GET.items()}
-        for bq in self.boolean_questions:
-            bq.active_filter = self.active_filters.get(bq.id, "")
-            param_key = f"q{bq.id}"
-            # URL for "yes" filter
-            yes_params = {k: v for k, v in base_params.items() if k != param_key}
-            yes_params[param_key] = "yes"
-            bq.filter_url_yes = "?" + "&".join(f"{k}={v}" for k, v in yes_params.items())
-            # URL for "no" filter
-            no_params = {k: v for k, v in base_params.items() if k != param_key}
-            no_params[param_key] = "no"
-            bq.filter_url_no = "?" + "&".join(f"{k}={v}" for k, v in no_params.items())
-        context["boolean_questions"] = self.boolean_questions
+        for fq in self.filter_questions:
+            fq.active_filter = self.active_filters.get(fq.id, "")
+            param_key = f"q{fq.id}"
+            other_params = {k: v for k, v in base_params.items() if k != param_key}
+            base_query = "&".join(f"{k}={v}" for k, v in other_params.items())
+            prefix = "?" + base_query + ("&" if base_query else "")
+
+            if fq.type == "boolean":
+                fq.filter_options = [
+                    ("yes", "Yes", f"{prefix}{param_key}=yes"),
+                    ("no", "No", f"{prefix}{param_key}=no"),
+                ]
+            elif fq.type == "integer":
+                fq.filter_options = []
+                for low, high in fq.integer_filter_ranges():
+                    val = f"{low}-{high}"
+                    label = str(low) if low == high else f"{low}–{high}"
+                    fq.filter_options.append((val, label, f"{prefix}{param_key}={val}"))
+            else:
+                fq.filter_options = []
+        context["filter_questions"] = self.filter_questions
         context["active_filters"] = self.active_filters
         return context
 

--- a/templates/program-applicants.html
+++ b/templates/program-applicants.html
@@ -18,27 +18,29 @@
         </div>
     {% endif %}
 
-    {% if user_can_manage and boolean_questions %}
+    {% if user_can_manage and filter_questions %}
         <div class="mb-4 p-4 bg-white rounded-lg shadow-sm border border-gray-200">
             <h3 class="text-sm font-medium text-gray-700 mb-3"><i class="fas fa-filter mr-1"></i> Filter by Question</h3>
-            <div class="flex flex-wrap gap-3 items-center">
-                {% for bq in boolean_questions %}
-                    <div class="flex items-center gap-1.5">
-                        <span class="text-sm text-gray-600">{{ bq.question }}</span>
-                        <a href="{{ bq.filter_url_yes }}"
-                           class="px-2 py-0.5 text-xs rounded-full border {% if bq.active_filter == 'yes' %}bg-emerald-100 text-emerald-800 border-emerald-300{% else %}bg-white text-gray-600 border-gray-300 hover:bg-gray-50{% endif %}">
-                            Yes
-                        </a>
-                        <a href="{{ bq.filter_url_no }}"
-                           class="px-2 py-0.5 text-xs rounded-full border {% if bq.active_filter == 'no' %}bg-red-100 text-red-800 border-red-300{% else %}bg-white text-gray-600 border-gray-300 hover:bg-gray-50{% endif %}">
-                            No
-                        </a>
-                    </div>
+            <div class="flex flex-col gap-2">
+                {% for fq in filter_questions %}
+                    {% if fq.filter_options %}
+                        <div class="flex flex-wrap items-center gap-1.5">
+                            <span class="text-sm text-gray-600 mr-1">{{ fq.question }}</span>
+                            {% for value, label, url in fq.filter_options %}
+                                <a href="{{ url }}"
+                                   class="px-2 py-0.5 text-xs rounded-full border {% if fq.active_filter == value %}bg-emerald-100 text-emerald-800 border-emerald-300{% else %}bg-white text-gray-600 border-gray-300 hover:bg-gray-50{% endif %}">
+                                    {{ label }}
+                                </a>
+                            {% endfor %}
+                        </div>
+                    {% endif %}
                 {% endfor %}
                 {% if active_filters %}
-                    <a href="{{ program.urls.applicants }}{% if viewing_rejected %}?status=rejected{% endif %}" class="px-2 py-0.5 text-xs text-gray-500 hover:text-gray-700 underline">
-                        Clear filters
-                    </a>
+                    <div>
+                        <a href="{{ program.urls.applicants }}{% if viewing_rejected %}?status=rejected{% endif %}" class="text-xs text-gray-500 hover:text-gray-700 underline">
+                            Clear filters
+                        </a>
+                    </div>
                 {% endif %}
             </div>
         </div>

--- a/templates/program-questions.html
+++ b/templates/program-questions.html
@@ -11,6 +11,7 @@
                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Question</th>
                         <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
                         <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Required</th>
+                        <th class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">Filter</th>
                         <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                     </tr>
                 </thead>
@@ -19,12 +20,14 @@
                         <td class="px-6 py-4 text-sm font-medium text-gray-900">Name</td>
                         <td class="px-6 py-4 text-sm text-gray-500">Text</td>
                         <td class="px-6 py-4 text-center"><i class="fas fa-check text-green-600"></i></td>
+                        <td class="px-6 py-4 text-center text-gray-400">—</td>
                         <td class="px-6 py-4 text-right text-sm text-gray-400 italic">Built-in</td>
                     </tr>
                     <tr class="bg-gray-50">
                         <td class="px-6 py-4 text-sm font-medium text-gray-900">Email</td>
                         <td class="px-6 py-4 text-sm text-gray-500">Email</td>
                         <td class="px-6 py-4 text-center"><i class="fas fa-check text-green-600"></i></td>
+                        <td class="px-6 py-4 text-center text-gray-400">—</td>
                         <td class="px-6 py-4 text-right text-sm text-gray-400 italic">Built-in</td>
                     </tr>
                     {% for question in questions %}
@@ -34,6 +37,15 @@
                             <td class="px-6 py-4 text-center">
                                 {% if question.required %}
                                     <i class="fas fa-check text-green-600"></i>
+                                {% else %}
+                                    <i class="fas fa-xmark text-gray-400"></i>
+                                {% endif %}
+                            </td>
+                            <td class="px-6 py-4 text-center">
+                                {% if question.can_filter %}
+                                    <i class="fas fa-filter text-emerald-600" title="Shown as a filter on the applicants list"></i>
+                                {% elif question.filterable %}
+                                    <span class="text-xs text-gray-400 italic" title="Filtering is only supported on Yes/No and Integer questions">N/A</span>
                                 {% else %}
                                     <i class="fas fa-xmark text-gray-400"></i>
                                 {% endif %}


### PR DESCRIPTION
- Adds a `filterable` flag on `Question` (default off) — replaces the old behavior where every Yes/No question auto-appeared as a filter
- **Yes/No questions:** same Yes/No filter buttons as before, now opt-in via the flag
- **Integer questions:** newly supported — quartile-based range buckets computed from actual answer data (e.g. `0–99`, `100–499`, `500–999`, `1000+`)
- Questions list page gets a new **Filter** column showing which questions are exposed
- Question edit form has a new **Filterable** checkbox
- Migration `0018` backfills `filterable=True` for all existing boolean questions so current programs keep their filters