### PR TITLE
Allow toggling off an active filter by clicking it

### DIFF
--- a/grants/tests/test_views.py
+++ b/grants/tests/test_views.py
@@ -135,6 +135,17 @@ class TestProgramApplicantsFilters:
         assert "SmallBudget" in body
         assert "LargeBudget" not in body
 
+    def test_active_filter_link_clears_itself(self, manager_client, program):
+        """Clicking the currently-active filter option should produce a URL
+        that omits its query param (toggle off)."""
+        q = baker.make("grants.Question", program=program, type="boolean", filterable=True)
+        response = manager_client.get(f"/{program.slug}/applicants/?q{q.id}=yes")
+        body = response.content.decode()
+        # The "Yes" link must not point back to ?q{id}=yes when yes is active.
+        assert f'href="?q{q.id}=yes"' not in body
+        # The "No" link should still point to ?q{id}=no.
+        assert f'href="?q{q.id}=no"' in body
+
     def test_filter_does_not_apply_for_non_managers(self, client_logged_in, program):
         """Non-managers should not be able to use filters even if URL has them."""
         q = baker.make("grants.Question", program=program, type="boolean", filterable=True)

--- a/grants/views/program.py
+++ b/grants/views/program.py
@@ -318,26 +318,34 @@ class ProgramApplicants(ProgramMixin, ListView):
         context = super().get_context_data()
         context["sort"] = self.sort
         context["viewing_rejected"] = self.viewing_rejected
-        # Build filter UI data for each filterable question
+        # Build filter UI data for each filterable question.
+        # Clicking an active filter clears it (toggle off); clicking another
+        # value replaces it.
         base_params = {k: v for k, v in self.request.GET.items()}
         for fq in self.filter_questions:
             fq.active_filter = self.active_filters.get(fq.id, "")
             param_key = f"q{fq.id}"
             other_params = {k: v for k, v in base_params.items() if k != param_key}
             base_query = "&".join(f"{k}={v}" for k, v in other_params.items())
-            prefix = "?" + base_query + ("&" if base_query else "")
+
+            def url_for(value, _other=base_query, _key=param_key, _active=fq.active_filter):
+                # If this value is already active, link clears the param.
+                params = _other
+                if value != _active:
+                    params = f"{params}&{_key}={value}" if params else f"{_key}={value}"
+                return "?" + params if params else "?"
 
             if fq.type == "boolean":
                 fq.filter_options = [
-                    ("yes", "Yes", f"{prefix}{param_key}=yes"),
-                    ("no", "No", f"{prefix}{param_key}=no"),
+                    ("yes", "Yes", url_for("yes")),
+                    ("no", "No", url_for("no")),
                 ]
             elif fq.type == "integer":
                 fq.filter_options = []
                 for low, high in fq.integer_filter_ranges():
                     val = f"{low}-{high}"
                     label = str(low) if low == high else f"{low}–{high}"
-                    fq.filter_options.append((val, label, f"{prefix}{param_key}={val}"))
+                    fq.filter_options.append((val, label, url_for(val)))
             else:
                 fq.filter_options = []
         context["filter_questions"] = self.filter_questions


### PR DESCRIPTION
- Clicking an already-active filter option (Yes / No / a range bucket) now clears that filter, instead of being a no-op
- Clicking a different option in the same group still replaces the value as before
- Useful when bouncing between Yes → No → unfiltered without trekking to the global **Clear filters** link