### PR TITLE
Add ability to stop scoring on a program

### DIFF
--- a/grants/forms.py
+++ b/grants/forms.py
@@ -129,4 +129,8 @@ class ApproveApplicantForm(forms.Form):
 class ProgramEditForm(forms.ModelForm):
     class Meta:
         model = Program
-        fields = ["name", "join_code"]
+        fields = ["name", "join_code", "completed"]
+        labels = {"completed": "Scoring closed"}
+        help_texts = {
+            "completed": "When checked, scoring is closed and reviewers can no longer submit scores.",
+        }

--- a/grants/tests/test_views.py
+++ b/grants/tests/test_views.py
@@ -186,6 +186,39 @@ class TestApplicantViewAndScoring:
         assert "3.0" in score.score_history
 
 
+class TestScoringClosed:
+    """When `Program.completed` is True, no new scores can be submitted."""
+
+    def test_score_submission_blocked_when_closed(self, client_logged_in, program, applicant, user):
+        program.completed = True
+        program.save()
+        response = client_logged_in.post(
+            f"/{program.slug}/applicants/{applicant.id}/",
+            {"score": 4.0, "comment": "Should not save"},
+        )
+        assert response.status_code == 404
+        assert not Score.objects.filter(applicant=applicant, user=user).exists()
+
+    def test_applicant_view_still_loads_when_closed(self, client_logged_in, program, applicant):
+        program.completed = True
+        program.save()
+        response = client_logged_in.get(f"/{program.slug}/applicants/{applicant.id}/")
+        assert response.status_code == 200
+
+    def test_random_unscored_redirects_when_closed(self, client_logged_in, program, applicant):
+        program.completed = True
+        program.save()
+        response = client_logged_in.get(f"/{program.slug}/applicants/random-unscored/")
+        assert response.status_code == 302
+        assert response.url.rstrip("/").endswith("/applicants")
+
+    def test_bulk_load_scores_blocked_when_closed(self, client_logged_in, program):
+        program.completed = True
+        program.save()
+        response = client_logged_in.get(f"/{program.slug}/applicants/bulk_scores/")
+        assert response.status_code == 404
+
+
 class TestOwnApplicationHiddenFromReviewer:
     """A user who also applied must never see their own application."""
 
@@ -311,24 +344,40 @@ class TestEditProgramView:
         assert response.status_code == 302
         assert "login" in response.url
 
-    def test_requires_staff_access(self, client, program, user):
+    def test_member_without_manage_rights_denied(self, client, program, user):
         program.users.add(user)
         client.force_login(user)
         response = client.get(f"/{program.slug}/edit/")
         assert response.status_code == 404
 
-    def test_accessible_to_staff(self, client, program, user):
+    def test_staff_user_who_is_not_creator_denied(self, client, program, user):
         user.is_staff = True
+        user.save()
+        program.users.add(user)
+        client.force_login(user)
+        response = client.get(f"/{program.slug}/edit/")
+        assert response.status_code == 404
+
+    def test_accessible_to_program_creator(self, client, program, user):
+        program.users.add(user)
+        program.created_by = user
+        program.save()
+        client.force_login(user)
+        response = client.get(f"/{program.slug}/edit/")
+        assert response.status_code == 200
+
+    def test_accessible_to_superuser(self, client, program, user):
+        user.is_superuser = True
         user.save()
         program.users.add(user)
         client.force_login(user)
         response = client.get(f"/{program.slug}/edit/")
         assert response.status_code == 200
 
-    def test_can_update_program_name(self, client, program, user):
-        user.is_staff = True
-        user.save()
+    def test_creator_can_update_program_name(self, client, program, user):
         program.users.add(user)
+        program.created_by = user
+        program.save()
         client.force_login(user)
         response = client.post(
             f"/{program.slug}/edit/",
@@ -338,10 +387,10 @@ class TestEditProgramView:
         program.refresh_from_db()
         assert program.name == "Updated Name"
 
-    def test_can_update_join_code(self, client, program, user):
-        user.is_staff = True
-        user.save()
+    def test_creator_can_update_join_code(self, client, program, user):
         program.users.add(user)
+        program.created_by = user
+        program.save()
         client.force_login(user)
         response = client.post(
             f"/{program.slug}/edit/",
@@ -350,3 +399,32 @@ class TestEditProgramView:
         assert response.status_code == 302
         program.refresh_from_db()
         assert program.join_code == "new-secret-code"
+
+    def test_creator_can_close_scoring(self, client, program, user):
+        program.users.add(user)
+        program.created_by = user
+        program.save()
+        client.force_login(user)
+        response = client.post(
+            f"/{program.slug}/edit/",
+            {
+                "name": program.name,
+                "join_code": program.join_code or program.slug,
+                "completed": "on",
+            },
+        )
+        assert response.status_code == 302
+        program.refresh_from_db()
+        assert program.completed is True
+
+    def test_non_creator_post_does_not_save(self, client, program, user):
+        program.users.add(user)
+        client.force_login(user)
+        original_name = program.name
+        response = client.post(
+            f"/{program.slug}/edit/",
+            {"name": "Hijacked", "join_code": program.join_code or program.slug},
+        )
+        assert response.status_code == 404
+        program.refresh_from_db()
+        assert program.name == original_name

--- a/grants/views/bulk_load.py
+++ b/grants/views/bulk_load.py
@@ -6,6 +6,7 @@ import datetime
 
 from django import forms
 from django.db.transaction import atomic
+from django.http import Http404
 from django.views.generic import TemplateView
 
 from ..forms import BulkLoadMapBaseForm, BulkLoadUploadForm
@@ -31,16 +32,12 @@ class BulkLoader(ProgramMixin):
         # If there's a CSV, load it into the database, otherwise retrieve
         # the one we stored there before.
         if "csv" in request.FILES:
-            csv_obj = UploadedCSV.objects.create(
-                csv=request.FILES["csv"].read().decode()
-            )
+            csv_obj = UploadedCSV.objects.create(csv=request.FILES["csv"].read().decode())
         else:
             csv_obj = UploadedCSV.objects.get(pk=request.POST["csv_id"])
 
         # We always get a CSV file - parse it.
-        reader = csv.reader(
-            [x + "\n" for x in csv_obj.csv.split("\n") if len(x.strip())]
-        )
+        reader = csv.reader([x + "\n" for x in csv_obj.csv.split("\n") if len(x.strip())])
 
         rows = list(reader)
         headers = rows[0]
@@ -49,9 +46,7 @@ class BulkLoader(ProgramMixin):
         fields = collections.OrderedDict(
             (
                 name,
-                forms.ChoiceField(
-                    choices=column_choices, required=required, label=label
-                ),
+                forms.ChoiceField(choices=column_choices, required=required, label=label),
             )
             for name, required, label in self.get_targets()
         )
@@ -63,11 +58,7 @@ class BulkLoader(ProgramMixin):
             # Save and import!
             errors = []
             successful = 0
-            target_map = {
-                name: int(value)
-                for name, value in form.cleaned_data.items()
-                if name != "csv_id" and value
-            }
+            target_map = {name: int(value) for name, value in form.cleaned_data.items() if name != "csv_id" and value}
             self.before_import(rows, target_map)
             for i, row in enumerate(rows[1:]):
                 try:
@@ -130,16 +121,12 @@ class BulkLoadApplicants(BulkLoader, TemplateView):
 
         # Check for duplicate email within this import
         if not self.program.duplicate_emails and email in self._imported_emails:
-            raise ValueError(
-                f"Duplicate email '{email}' - this email already appeared earlier in the CSV"
-            )
+            raise ValueError(f"Duplicate email '{email}' - this email already appeared earlier in the CSV")
         self._imported_emails.add(email)
         if self.program.duplicate_emails:
             applicant = None
         else:
-            applicant = Applicant.objects.filter(
-                program=self.program, email=row[target_map["email"]]
-            ).first()
+            applicant = Applicant.objects.filter(program=self.program, email=row[target_map["email"]]).first()
         if not applicant:
             applicant = Applicant(
                 program=self.program,
@@ -156,9 +143,7 @@ class BulkLoadApplicants(BulkLoader, TemplateView):
         if "timestamp" in target_map:
             for time_format in self.time_formats:
                 try:
-                    applicant.applied = datetime.datetime.strptime(
-                        row[target_map["timestamp"]], time_format
-                    )
+                    applicant.applied = datetime.datetime.strptime(row[target_map["timestamp"]], time_format)
                 except ValueError:
                     pass
         applicant.save()
@@ -169,10 +154,7 @@ class BulkLoadApplicants(BulkLoader, TemplateView):
                 question = self.program.questions.get(pk=key.lstrip("q"))
                 if question.type == "boolean":
                     answer = str(
-                        not any(
-                            (raw_answer.lower().strip() == no_word)
-                            for no_word in ("no", "false", "off", "", "0")
-                        )
+                        not any((raw_answer.lower().strip() == no_word) for no_word in ("no", "false", "off", "", "0"))
                     )
                 elif question.type == "integer":
                     if not raw_answer.strip():
@@ -182,14 +164,11 @@ class BulkLoadApplicants(BulkLoader, TemplateView):
                             answer = str(int(raw_answer.strip()))
                         except ValueError:
                             raise ValueError(
-                                "Invalid integer value for question %s: %s"
-                                % (question.question, raw_answer)
+                                "Invalid integer value for question %s: %s" % (question.question, raw_answer)
                             )
                 else:
                     answer = raw_answer
-                answer_obj = Answer.objects.filter(
-                    applicant=applicant, question=question
-                ).first()
+                answer_obj = Answer.objects.filter(applicant=applicant, question=question).first()
                 if not answer_obj:
                     answer_obj = Answer(
                         applicant=applicant,
@@ -206,6 +185,16 @@ class BulkLoadScores(BulkLoader, TemplateView):
 
     template_name = "program-bulk-scores.html"
 
+    def get(self, request, *args, **kwargs):
+        if self.program.completed:
+            raise Http404("Scoring is closed for this program")
+        return super().get(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        if self.program.completed:
+            raise Http404("Scoring is closed for this program")
+        return super().post(request, *args, **kwargs)
+
     def get_targets(self):
         return [
             ("email", True, "Email"),
@@ -216,9 +205,7 @@ class BulkLoadScores(BulkLoader, TemplateView):
     def process_row(self, row, target_map):
         applicant = Applicant.objects.get(email=row[target_map["email"]])
 
-        score = Score.objects.get_or_create(
-            applicant=applicant, user=self.request.user
-        )[0]
+        score = Score.objects.get_or_create(applicant=applicant, user=self.request.user)[0]
         score_value = row[target_map["score"]]
         try:
             score.score = float(score_value)

--- a/grants/views/program.py
+++ b/grants/views/program.py
@@ -125,21 +125,22 @@ class ProgramHome(ProgramMixin, TemplateView):
 
 class EditProgram(ProgramMixin, UpdateView):
     """
-    Allows staff users to edit program settings.
+    Allows superusers and the program creator to edit program settings.
     """
 
     template_name = "program-edit.html"
     form_class = ProgramEditForm
     model = Program
 
-    def dispatch(self, *args, **kwargs):
-        result = super().dispatch(*args, **kwargs)
-        # If we got a redirect (e.g., to login), return it
-        if hasattr(result, "status_code") and result.status_code in (301, 302):
-            return result
-        if not self.request.user.is_staff:
-            raise Http404("Staff access required")
-        return result
+    def get(self, request, *args, **kwargs):
+        if not self.program.user_can_manage(request.user):
+            raise Http404("Only superusers and the program creator can edit this program")
+        return super().get(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        if not self.program.user_can_manage(request.user):
+            raise Http404("Only superusers and the program creator can edit this program")
+        return super().post(request, *args, **kwargs)
 
     def get_object(self):
         return self.program
@@ -465,6 +466,8 @@ class ProgramApplicantView(ProgramMixin, TemplateView):
                     applicant.rejection_reason = reject_form.cleaned_data["rejection_reason"]
                     applicant.save()
                     return redirect(self.program.urls.applicants)
+            elif self.program.completed:
+                raise Http404("Scoring is closed for this program")
             else:
                 form = ScoreForm(request.POST, instance=score)
                 if form.is_valid():
@@ -491,6 +494,7 @@ class ProgramApplicantView(ProgramMixin, TemplateView):
                 "form": form,
                 "reject_form": reject_form,
                 "approve_form": approve_form,
+                "scoring_closed": self.program.completed,
             }
         )
 
@@ -504,6 +508,8 @@ class RandomUnscoredApplicant(ProgramMixin, View):
     """
 
     def get(self, request):
+        if self.program.completed:
+            return redirect(self.program.urls.applicants)
         applicant = (
             self.program.applicants_visible_to(self.request.user)
             .exclude(Q(scores__user=self.request.user) | Q(status="rejected"))

--- a/templates/applicant-view.html
+++ b/templates/applicant-view.html
@@ -79,7 +79,14 @@
         <div class="lg:col-span-1 space-y-6">
             <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 sticky top-6">
                 <h3 class="text-lg font-semibold text-gray-900 mb-4">Submit Score</h3>
-                {% include "_form.html" with submit_verb="Save" include_random=1 %}
+                {% if scoring_closed %}
+                    <p class="text-sm text-amber-800 bg-amber-50 border border-amber-200 rounded-md p-3">
+                        <i class="fas fa-lock mr-1"></i>
+                        Scoring is closed for this program.
+                    </p>
+                {% else %}
+                    {% include "_form.html" with submit_verb="Save" include_random=1 %}
+                {% endif %}
             </div>
 
             {% if approve_form %}

--- a/templates/program-applicants.html
+++ b/templates/program-applicants.html
@@ -182,9 +182,11 @@
             <a href="{{ program.urls.applicants_bulk }}" class="inline-flex items-center px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium rounded-md transition-colors text-sm">
                 <i class="fas fa-upload mr-2"></i> Bulk Load Applicants
             </a>
-            <a href="{{ program.urls.scores_bulk }}" class="inline-flex items-center px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium rounded-md transition-colors text-sm">
-                <i class="fas fa-upload mr-2"></i> Bulk Load Scores
-            </a>
+            {% if not program.completed %}
+                <a href="{{ program.urls.scores_bulk }}" class="inline-flex items-center px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium rounded-md transition-colors text-sm">
+                    <i class="fas fa-upload mr-2"></i> Bulk Load Scores
+                </a>
+            {% endif %}
             <a href="{{ program.urls.applicants_csv }}" class="inline-flex items-center px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium rounded-md transition-colors text-sm">
                 <i class="fas fa-download mr-2"></i> Export as CSV
             </a>

--- a/templates/program-home.html
+++ b/templates/program-home.html
@@ -3,12 +3,18 @@
 {% block title %}{{ program }}{% endblock %}
 
 {% block content %}
-    {% if request.user.is_staff %}
+    {% if user_can_manage %}
         <div class="mb-4 flex justify-end">
             <a href="{{ program.urls.edit }}" class="inline-flex items-center px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-md transition-colors">
                 <i class="fas fa-cog mr-2"></i>
                 Edit Program
             </a>
+        </div>
+    {% endif %}
+    {% if program.completed %}
+        <div class="mb-4 p-4 bg-amber-50 border border-amber-200 rounded-md text-amber-800 text-sm flex items-center">
+            <i class="fas fa-lock mr-2"></i>
+            Scoring is closed for this program. Reviewers can no longer submit scores.
         </div>
     {% endif %}
     <div class="bg-emerald-50 rounded-lg border-2 border-emerald-300 p-6 mb-6">
@@ -66,7 +72,7 @@
                 <a href="{{ program.urls.applicants }}" class="inline-flex items-center px-4 py-2 bg-gray-100 hover:bg-gray-200 text-gray-700 font-medium rounded-md transition-colors text-sm">
                     View All
                 </a>
-                {% if num_scored < num_applicants %}
+                {% if num_scored < num_applicants and not program.completed %}
                     <a href="{{ program.urls.score_random }}" class="inline-flex items-center px-4 py-2 bg-emerald-600 hover:bg-emerald-700 text-white font-medium rounded-md transition-colors text-sm">
                         Score Random
                     </a>


### PR DESCRIPTION
## Summary
- Reuses the previously-unused `Program.completed` flag as a manual switch to close scoring; when set, the per-applicant score POST, `RandomUnscoredApplicant`, and `BulkLoadScores` all return 404, and the score form / "Score Random" / "Bulk Load Scores" UI is hidden behind a "scoring closed" notice.
- Exposes `completed` in `ProgramEditForm` (label "Scoring closed") so it can be toggled from the edit-program page.
- Restricts editing the program (and therefore the new flag) to superusers and the program creator via `Program.user_can_manage`, replacing the prior `is_staff` gate. The check now runs in `get`/`post` rather than after `super().dispatch()`, so an unauthorized POST can't save before the 404 fires.